### PR TITLE
CSS extracted from a JS chunk has no top-level manifest entry — emit …

### DIFF
--- a/models/Vite.cfc
+++ b/models/Vite.cfc
@@ -71,6 +71,10 @@ component singleton accessors="true" {
 					var partialManifest = manifest.filter( ( key, value ) => value.file == css );
 
 					if ( partialManifest.isEmpty() ) {
+						// CSS extracted from a JS chunk has no top-level manifest entry — emit a direct link tag
+						var cssPath = generateAssetPath( css );
+						preloads.append( { "src": css, "path": cssPath, "chunk": {}, "manifest": manifest } );
+						tags.append( generateStylesheetTagWithAttributes( cssPath ) );
 						continue;
 					}
 
@@ -106,6 +110,10 @@ component singleton accessors="true" {
 				var partialManifest = manifest.filter( ( key, value ) => value.file == css );
 
 				if ( partialManifest.isEmpty() ) {
+					// CSS extracted from a JS chunk has no top-level manifest entry — emit a direct link tag
+					var cssPath = generateAssetPath( css );
+					preloads.append( { "src": css, "path": cssPath, "chunk": {}, "manifest": manifest } );
+					tags.append( generateStylesheetTagWithAttributes( cssPath ) );
 					continue;
 				}
 


### PR DESCRIPTION
…a direct link tag